### PR TITLE
Not display errors when page is loaded for the first time

### DIFF
--- a/daterange_filter/filter.py
+++ b/daterange_filter/filter.py
@@ -211,6 +211,11 @@ class DateTimeRangeFilter(admin.filters.FieldListFilter):
         return DateTimeRangeForm(request, data=self.used_parameters, field_name=self.field_path)
 
     def queryset(self, request, queryset):
+        if not self.form.data:
+            # not display errors when page is loaded for the first time
+            for key in self.form.errors:
+                self.form.errors[key] = ''
+
         if self.form.is_valid():
             # get no null params
             filter_params = clean_input_prefix(dict(filter(lambda x: bool(x[1]), self.form.cleaned_data.items())))


### PR DESCRIPTION
#### 1) Errors occur when the admin portal page is loaded for the first time
<img width="212" alt="screen shot 2017-02-28 at 4 06 20 pm" src="https://cloud.githubusercontent.com/assets/4997873/23471922/100b831a-fe79-11e6-905b-6fb6f62f01a0.png">
This PR will solve the problem stated above.

#### 2) `DateTimeRangeForm` validation is not correct
<img width="216" alt="screen shot 2017-02-28 at 12 03 17 pm" src="https://cloud.githubusercontent.com/assets/4997873/23472077/b2145308-fe79-11e6-81b0-39847eea05aa.png">

#### 3) `DateRangeFilter` is not working

This PR will solve problem 1). I was trying to open an issue about 2) and 3), however, issue page is not enabled for this project. 